### PR TITLE
Use escape sequence to denote tab character

### DIFF
--- a/deploy/ansible/roles/configure/tasks/main.yml
+++ b/deploy/ansible/roles/configure/tasks/main.yml
@@ -47,6 +47,6 @@
     dest=/etc/sudoers
     state=present
     regexp="^%sudo"
-    line="%sudo	ALL=(ALL:ALL) NOPASSWD:ALL"
+    line="%sudo\tALL=(ALL:ALL) NOPASSWD:ALL"
     validate="visudo -cf %s"
   when: env == "development"


### PR DESCRIPTION
Running in Ubuntu Linux, Ansible 1.9.2 rejects the literal "tab"
character within a double-quote-delimited string. Prefer the `\t`
("backslash-T") escape sequence for platform interoperability and for
configuration clarity.