### PR TITLE
disable retry files

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -3,3 +3,5 @@ transport = ssh
 
 [ssh_connection]
 ssh_args = -o ForwardAgent=yes
+
+retry_files_enabled = False


### PR DESCRIPTION
this keeps the workflow from cluttering the `~` aka home directory with `.retry` files