### PR TITLE
add quotes to install apt name

### DIFF
--- a/deploy/ansible/roles/base/tasks/main.yml
+++ b/deploy/ansible/roles/base/tasks/main.yml
@@ -21,7 +21,7 @@
 
 - name: install apt packages
   apt:
-    name: {{item}}
+    name: "{{item}}"
     state: latest
   with_items: apt_packages
 


### PR DESCRIPTION
ansible fails to run at this point without the name in quotes :santa: