### PR TITLE
move handlers to configure playbook directly

### DIFF
--- a/deploy/ansible/configure.yml
+++ b/deploy/ansible/configure.yml
@@ -10,4 +10,7 @@
     - {role: users, tags: users}
     - {role: nginx, tags: nginx}
   handlers:
-    - include: handlers/handlers.yml
+    - name: restart nginx
+      service: name=service state=restarted
+    - name: restart sshd
+      service: name=ssh state=restarted

--- a/deploy/ansible/deploy.yml
+++ b/deploy/ansible/deploy.yml
@@ -8,5 +8,3 @@
   become_method: sudo
   roles:
     - deploy
-  handlers:
-    - include: handlers/handlers.yml

--- a/deploy/ansible/handlers/handlers.yml
+++ b/deploy/ansible/handlers/handlers.yml
@@ -1,6 +1,0 @@
-- name: restart nginx
-  service: name=nginx state=restarted
-- name: restart sshd
-  command: service ssh restart
-  # https://github.com/ansible/ansible-modules-core/pull/999
-  # service: name=ssh state=restarted

--- a/deploy/ansible/provision.yml
+++ b/deploy/ansible/provision.yml
@@ -9,5 +9,3 @@
   become_method: sudo
   roles:
     - {role: base, tags: base}
-  handlers:
-    - include: handlers/handlers.yml


### PR DESCRIPTION
ansible 2.0 added some powerful features around dynamic includes.
this broke which broke static analysis of includes... which broke
handlers being referenced as external files.

http://www.ansible.com/blog/ansible-2.0-launch