### PR TITLE
update handling of agent forwarding

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,7 +1,0 @@
-[defaults]
-transport = ssh
-
-[ssh_connection]
-ssh_args = -o ForwardAgent=yes
-
-retry_files_enabled = False

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -143,7 +143,12 @@ remote: bocoup
 commit: master
 
 # Git repo address.
-git_repo: git@github.com:{{remote}}/{{project_name}}.git
+# For private repositories: git@github.com:{{remote}}/{{project_name}}.git
+# For public: https://github.com/{{remote}}/{{project_name}}
+git_repo: https://github.com/{{remote}}/{{project_name}}
+
+# Uncomment this if if you are checking out a private repo
+# ansible_ssh_common_args: -o ForwardAgent=yes
 
 # Clone and build the specified commit SHA, regardless of prior build status.
 force: false


### PR DESCRIPTION
this pr removes ansible.cfg (which only works when ansible is run
from the same folder) in favor of `ansible_ssh_common_args` (which
works as a variable defined anywhere) to manage agent forwarding.

as a side note, retry files are a thing of the past with ansible
2.0 so we don't need to retain that either.