### PR TITLE
Use certbot to generate/renew letsencrypt ssl certs. Closes #91.

### DIFF
--- a/deploy/ansible/configure.yml
+++ b/deploy/ansible/configure.yml
@@ -10,7 +10,7 @@
     - {role: users, tags: users}
     - {role: nginx, tags: nginx}
   handlers:
-    - name: restart nginx
-      service: name=nginx state=restarted
+    - name: reload nginx
+      service: name=nginx state=reloaded
     - name: restart sshd
       service: name=ssh state=restarted

--- a/deploy/ansible/group_vars/all.yml
+++ b/deploy/ansible/group_vars/all.yml
@@ -51,11 +51,12 @@ apt_packages:
 # Should the nginx server use HTTPS instead of HTTP?
 ssl: true
 
-# If ssl is enabled, these cert/key files will be used by nginx. You will need
-# to ensure these files are valid and already on the server (which you can do
-# via cloud-init, scp, etc).
-ssl_cert_path: /etc/ssl/star.bocoup.com.cert
-ssl_key_path: /etc/ssl/star.bocoup.com.key
+# If ssl is enabled, these cert/key files will be used by nginx.
+ssl_cert_path: /etc/ssl/cert.pem
+ssl_key_path: /etc/ssl/privkey.pem
+
+# If ssl is enabled, email address to receive notifications from letsencrypt.
+letsencrypt_email: infrastructure@bocoup.com
 
 # Use a custom parameter for stronger DHE key exchange.
 dhe_param_path: /etc/ssl/certs/dhparam.pem

--- a/deploy/ansible/host_vars/vagrant
+++ b/deploy/ansible/host_vars/vagrant
@@ -19,8 +19,3 @@ site_fqdn: "{{project_name}}.loc"
 
 # Should the nginx server use HTTPS instead of HTTP?
 ssl: false
-
-# If ssl is enabled, these cert/key files will be used by nginx. Self-signed
-# cert/key files will be auto-generated if they don't already exist.
-ssl_cert_path: /etc/ssl/server.cert
-ssl_key_path: /etc/ssl/server.key

--- a/deploy/ansible/roles/nginx/tasks/certbot.yml
+++ b/deploy/ansible/roles/nginx/tasks/certbot.yml
@@ -44,8 +44,9 @@
     - { src: 'privkey.pem', dest: '{{ssl_key_path}}' }
   notify: reload nginx
 
-- name: install certbot post-hook script
-  template:
-    src: reload-nginx
-    dest: /etc/letsencrypt/post-hook.d/reload-nginx
-    mode: 0755
+- name: Add cron job for cert renewal
+  cron:
+    name: Certbot automatic renewal.
+    job: "/usr/bin/certbot renew --quiet --no-self-upgrade && service nginx reload"
+    minute: 0
+    hour: 23

--- a/deploy/ansible/roles/nginx/tasks/certbot.yml
+++ b/deploy/ansible/roles/nginx/tasks/certbot.yml
@@ -7,7 +7,7 @@
 
 - name: install certbot
   apt:
-    name: certbot
+    name: certbot=0.14.*
     state: present
 
 - name: ensure certbot well-known path exists

--- a/deploy/ansible/roles/nginx/tasks/certbot.yml
+++ b/deploy/ansible/roles/nginx/tasks/certbot.yml
@@ -1,0 +1,51 @@
+# Use certbot to generate letsencrypt ssl certs. This will also set up a cron
+# job that will ensure the certs are kept up-to-date.
+
+- name: add certbot ppa to apt
+  apt_repository:
+    repo: "ppa:certbot/certbot"
+
+- name: install certbot
+  apt:
+    name: certbot
+    state: present
+
+- name: ensure certbot well-known path exists
+  file:
+    path: "{{base_path}}/certbot/.well-known"
+    state: directory
+
+- name: test if certbot has been initialized
+  stat:
+    path: /etc/letsencrypt/live/{{site_fqdn}}/fullchain.pem
+  register: cert_file
+
+- name: ensure any pending nginx reload happens immediately
+  meta: flush_handlers
+  when: cert_file.stat.exists == false
+
+- name: intialize certbot
+  command: >
+    certbot certonly --webroot --agree-tos --non-interactive
+    {{ (env == 'production') | ternary('', '--test-cert') }}
+    --email {{letsencrypt_email}}
+    -w {{base_path}}/certbot
+    -d {{site_fqdn}}
+  when: cert_file.stat.exists == false
+
+- name: ensure certbot certs are linked
+  file:
+    src: '/etc/letsencrypt/live/{{site_fqdn}}/{{item.src}}'
+    dest: '{{item.dest}}'
+    state: link
+    force: true
+  with_items:
+    - { src: 'fullchain.pem', dest: '{{ssl_cert_path}}' }
+    - { src: 'privkey.pem', dest: '{{ssl_key_path}}' }
+  notify: reload nginx
+
+- name: install certbot post-hook script
+  template:
+    src: reload-nginx
+    dest: /etc/letsencrypt/post-hook.d/reload-nginx
+    mode: 0755

--- a/deploy/ansible/roles/nginx/tasks/main.yml
+++ b/deploy/ansible/roles/nginx/tasks/main.yml
@@ -54,3 +54,6 @@
 
 - fail: msg="nginx config is invalid"
   when: nginx_test_valid | failed
+
+- include: certbot.yml
+  when: ssl

--- a/deploy/ansible/roles/nginx/tasks/main.yml
+++ b/deploy/ansible/roles/nginx/tasks/main.yml
@@ -56,4 +56,4 @@
   when: nginx_test_valid | failed
 
 - include: certbot.yml
-  when: ssl
+  when: ssl and inventory_hostname != 'vagrant'

--- a/deploy/ansible/roles/nginx/tasks/main.yml
+++ b/deploy/ansible/roles/nginx/tasks/main.yml
@@ -29,7 +29,7 @@
   with_flattened:
     - "{{ confs }}"
     - "{{ shared }}"
-  notify: restart nginx
+  notify: reload nginx
 
 - name: ensure nginx config is valid
   shell: nginx -t

--- a/deploy/ansible/roles/nginx/tasks/ssl.yml
+++ b/deploy/ansible/roles/nginx/tasks/ssl.yml
@@ -5,7 +5,7 @@
   shell: openssl dhparam -dsaparam -out {{dhe_param_path}} 4096
   args:
     creates: "{{dhe_param_path}}"
-  notify: restart nginx
+  notify: reload nginx
 
 - name: create self-signed ssl cert/key - development only!
   command: >
@@ -15,7 +15,7 @@
   args:
     creates: "{{ssl_cert_path}}"
   when: env == "development"
-  notify: restart nginx
+  notify: reload nginx
 
 - name: ensure ssl cert/key exist
   stat: path={{item}}

--- a/deploy/ansible/roles/nginx/tasks/ssl.yml
+++ b/deploy/ansible/roles/nginx/tasks/ssl.yml
@@ -7,14 +7,13 @@
     creates: "{{dhe_param_path}}"
   notify: reload nginx
 
-- name: create self-signed ssl cert/key - development only!
+- name: create self-signed ssl cert/key
   command: >
     openssl req -new -nodes -x509
     -subj "/C=US/ST=Oregon/L=Portland/O=IT/CN={{site_fqdn}}" -days 3650
     -keyout {{ssl_key_path}} -out {{ssl_cert_path}} -extensions v3_ca
   args:
     creates: "{{ssl_cert_path}}"
-  when: env == "development"
   notify: reload nginx
 
 - name: ensure ssl cert/key exist

--- a/deploy/ansible/roles/nginx/templates/reload-nginx
+++ b/deploy/ansible/roles/nginx/templates/reload-nginx
@@ -1,2 +1,0 @@
-#!/bin/bash
-/etc/init.d/nginx reload

--- a/deploy/ansible/roles/nginx/templates/reload-nginx
+++ b/deploy/ansible/roles/nginx/templates/reload-nginx
@@ -1,0 +1,2 @@
+#!/bin/bash
+/etc/init.d/nginx reload

--- a/deploy/ansible/roles/nginx/templates/site.conf
+++ b/deploy/ansible/roles/nginx/templates/site.conf
@@ -11,7 +11,7 @@ server {
   root {{public_path}};
   index index.html;
   error_page 404 /404.html;
-{% if ssl %}
+{% if ssl and inventory_hostname != 'vagrant' %}
 
   # This allows certbot to get letsencrypt certs.
   location /.well-known {

--- a/deploy/ansible/roles/nginx/templates/site.conf
+++ b/deploy/ansible/roles/nginx/templates/site.conf
@@ -12,6 +12,11 @@ server {
   index index.html;
   error_page 404 /404.html;
 
+  # This allows certbot to get letsencrypt certs.
+  location /.well-known {
+    alias {{base_path}}/certbot/.well-known;
+  }
+
   # If you want to redirect everything to index.html (eg. for a web app),
   # remove the error_page line above and uncomment this block:
   # location / {

--- a/deploy/ansible/roles/nginx/templates/site.conf
+++ b/deploy/ansible/roles/nginx/templates/site.conf
@@ -11,11 +11,13 @@ server {
   root {{public_path}};
   index index.html;
   error_page 404 /404.html;
+{% if ssl %}
 
   # This allows certbot to get letsencrypt certs.
   location /.well-known {
     alias {{base_path}}/certbot/.well-known;
   }
+{% endif %}
 
   # If you want to redirect everything to index.html (eg. for a web app),
   # remove the error_page line above and uncomment this block:


### PR DESCRIPTION
1. Reload nginx instead of restarting it. Closes #96.
2. Use certbot to generate/renew letsencrypt ssl certs. Closes #91.

To test, I did the following:

Used `terraform apply` with a config like this:

```
provider "aws" {
  region = "us-east-1"
  profile = "bocoup"
}

data "aws_ami" "ubuntu" {
  most_recent = true
  filter {
    name = "name"
    values = ["ubuntu/images/hvm-ssd/ubuntu-trusty-14.04-amd64-server-*"]
  }
  filter {
    name = "virtualization-type"
    values = ["hvm"]
  }
  # Canonical
  owners = ["099720109477"]
}

resource "aws_instance" "main" {
  ami = "${data.aws_ami.ubuntu.id}"
  instance_type = "t2.nano"
  key_name = "ssl"
  subnet_id = "subnet-81e779d9"
  vpc_security_group_ids = [
    "${aws_security_group.main.id}",
  ]
}

resource "aws_security_group" "main" {
  vpc_id = "vpc-535fbb34"
  ingress {
    from_port = 22
    to_port = 22
    protocol = "tcp"
    cidr_blocks = ["0.0.0.0/0"]
  }
  ingress {
    from_port = 80
    to_port = 80
    protocol = "tcp"
    cidr_blocks = ["0.0.0.0/0"]
  }
  ingress {
    from_port = 443
    to_port = 443
    protocol = "tcp"
    cidr_blocks = ["0.0.0.0/0"]
  }
  egress {
    from_port = 0
    to_port = 0
    protocol = "-1"
    cidr_blocks = ["0.0.0.0/0"]
  }
}

resource "aws_route53_record" "dwtest-bocoup-com" {
  zone_id = "Z16P6HR2I1RPDU"
  type = "A"
  name = "dwtest"
  ttl = "1"
  records = ["${aws_instance.main.public_ip}"]
}
```

Used a `deploy/ansible/inventory/staging` file like this:

```
dwtest.bocoup.com site_fqdn=dwtest.bocoup.com
```

To run `ansible-playbook` like this:

```bash
$ ansible-playbook deploy/ansible/provision.yml \
  --inventory=deploy/ansible/inventory/staging \
  --user=ubuntu --key-file=../server.pem
$ ansible-playbook deploy/ansible/configure.yml \
  --inventory=deploy/ansible/inventory/staging \
  --user=ubuntu --key-file=../server.pem
```

Once that was done, I hit the server with `curl` to verify that the certs were valid:

```bash
$ curl -v https://dwtest.bocoup.com/
```

Note that there's a limit to the number of times certs can be requested in a 7-day window, so change `dwtest` to something different before testing.

If you want to use the letsencrypt staging cert server, set `env=development` in the inventory or via `--extra-vars`. However, if you do that, be sure to add `-k` to any `curl` command.

A few other things you can do:

```bash
# View cert info
$ ssh ubuntu@dwtest.bocoup.com -i ../server.pem "sudo certbot certificates"

# Print current cert expiration date
$ curl -v https://dwtest.bocoup.com/ 2>&1 | grep expire

# Force cert renewal (the /etc/cron.d/certbot command, with --force-renewal added)
$ ssh ubuntu@dwtest.bocoup.com -i ../server.pem "sudo certbot -q renew \
  --pre-hook '/bin/run-parts /etc/letsencrypt/pre-hook.d/' \
  --post-hook '/bin/run-parts /etc/letsencrypt/post-hook.d/' \
  --renew-hook '/bin/run-parts /etc/letsencrypt/renew-hook.d/' \
  --force-renewal"
```

If you print the cert expiration date before and after forcing cert renewal, and it changes:
  1. certbot fetched the new certs
  2. nginx was actually reloaded (otherwise you wouldn't see the expiration date change)