### PR TITLE
Remove locked certbot version

### DIFF
--- a/deploy/ansible/roles/nginx/tasks/certbot.yml
+++ b/deploy/ansible/roles/nginx/tasks/certbot.yml
@@ -7,7 +7,7 @@
 
 - name: install certbot
   apt:
-    name: certbot=0.14.*
+    name: certbot
     state: present
 
 - name: ensure certbot well-known path exists


### PR DESCRIPTION
No-can-do on locking the version. EFF removes old certbot versions from the PPA (probably for good reason). This just failed on me today because the only available version is 0.17.